### PR TITLE
This is NOT ROT13

### DIFF
--- a/rot13_test.go
+++ b/rot13_test.go
@@ -37,3 +37,12 @@ func TestRoundTrip(t *testing.T) {
 	assert.Equal(t, len(orig), len(rt.Bytes()), "Size of round-tripped didn't equal original")
 	assert.Equal(t, orig, rt.Bytes(), "Round-tripped didn't equal original")
 }
+
+func TestRot13(t *testing.T) {
+	var b bytes.Buffer
+	w := NewWriter(&b)
+	w.Write([]byte("amnzAMNZ"))
+	if b.String() != "nzamNZAM" {
+		t.Errorf("Not ROT13: got %q", b.String())
+	}
+}


### PR DESCRIPTION
The [common ROT13 algorithm](https://en.wikipedia.org/wiki/ROT13) is only defined on letters, not on any byte value like this implementation.
This patch adds a failing test that shows how this implementation does not interop with the ROT13 algorithm.